### PR TITLE
Add definition for missing var

### DIFF
--- a/Subdivision.php
+++ b/Subdivision.php
@@ -35,10 +35,11 @@ class Subdivision
     
     /**
      * @param string $path
+     * @param bool $assoc
      *
      * @return array
      */ 
-    protected static function loadJsonFile($path) 
+    protected static function loadJsonFile($path, $assoc = false) 
     {
         $data = array();
         


### PR DESCRIPTION
`$assoc` was not defined. Assuming it was meant to be passed as a method parameter. This should fix it.